### PR TITLE
fix reasoning_effort arg

### DIFF
--- a/state_bench/agents/state_bench.py
+++ b/state_bench/agents/state_bench.py
@@ -57,6 +57,7 @@ class StateBenchAgent(BaseAgent):
         tool_handlers: dict[str, Callable],
         runtime_context: AgentRuntimeContext | None = None,
         retrieve_learnings_top_k: int = 3,
+        agent_reasoning_effort: str | None = None,
     ):
         super().__init__(runtime_context=runtime_context)
         if not isinstance(client, (LLMClient, PooledLLMClient)):
@@ -70,8 +71,11 @@ class StateBenchAgent(BaseAgent):
             or retrieve_learnings_top_k < 1
         ):
             raise ValueError("retrieve_learnings_top_k must be an integer >= 1")
+        if agent_reasoning_effort is not None and agent_reasoning_effort not in {"low", "medium", "high"}:
+            raise ValueError("agent_reasoning_effort must be one of 'low', 'medium', 'high', or None")
         self.client = client
         self.retrieve_learnings_top_k = retrieve_learnings_top_k
+        self.agent_reasoning_effort = agent_reasoning_effort
         self.retrieval_enabled = self._has_retrieve_learnings()
         self.system_prompt = (
             self._with_retrieval_instruction(system_prompt) if self.retrieval_enabled else system_prompt
@@ -131,6 +135,7 @@ class StateBenchAgent(BaseAgent):
                 instructions=self.system_prompt,
                 input=prepared_conversation,
                 tools=self.tools,
+                reasoning_effort=self.agent_reasoning_effort,
             )
             if response.usage:
                 self.total_output_tokens += response.usage.output_tokens
@@ -176,6 +181,7 @@ class StateBenchAgent(BaseAgent):
                     input=tool_results,
                     tools=self.tools,
                     previous_response_id=response.id,
+                    reasoning_effort=self.agent_reasoning_effort,
                 )
                 if response.usage:
                     self.total_output_tokens += response.usage.output_tokens

--- a/state_bench/client.py
+++ b/state_bench/client.py
@@ -399,6 +399,7 @@ class LLMClient(BaseLLMClient):
         previous_response_id: str | None = None,
         max_tokens: int = 4096,
         temperature: float | None = 0,
+        reasoning_effort: str | None = None,
     ) -> Any:
         """Call the Responses API with tool schemas.
 
@@ -413,7 +414,11 @@ class LLMClient(BaseLLMClient):
             "previous_response_id": previous_response_id,
             "max_output_tokens": max_tokens,
         }
-        if temperature is not None:
+        if reasoning_effort:
+            # Azure GPT-5.1 reasoning models reject `temperature` alongside `reasoning`
+            # (HTTP 400 invalid_request_error). Omit it rather than fail the request.
+            kwargs["reasoning"] = {"effort": reasoning_effort}
+        elif temperature is not None:
             kwargs["temperature"] = temperature
         response = self._client.responses.create(**kwargs)
         _check_content_filter(response)

--- a/state_bench/orchestrator.py
+++ b/state_bench/orchestrator.py
@@ -11,6 +11,7 @@ Domain-agnostic: all domain-specific behavior is provided via DomainConfig.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import time
 from typing import Any
@@ -135,6 +136,7 @@ def run_task(
     agent_pricing: AgentPricing | None = None,
     agent_class: type[BaseAgent] | None = None,
     retrieve_learnings_top_k: int = 3,
+    agent_reasoning_effort: str | None = None,
 ) -> Trajectory:
     """Run a single task and return the trajectory.
 
@@ -179,13 +181,31 @@ def run_task(
             task_requirements=task.task_requirements,
             agent_pricing=agent_pricing,
         )
+        agent_kwargs: dict[str, Any] = {
+            "runtime_context": runtime_context,
+            "retrieve_learnings_top_k": retrieve_learnings_top_k,
+        }
+        # Custom agent subclasses may not accept agent_reasoning_effort; only pass when supported.
+        if agent_reasoning_effort is not None:
+            try:
+                accepts = "agent_reasoning_effort" in inspect.signature(resolved_agent_class).parameters
+            except (TypeError, ValueError):
+                accepts = False
+            if accepts:
+                agent_kwargs["agent_reasoning_effort"] = agent_reasoning_effort
+            else:
+                logger.warning(
+                    "Agent class %s does not accept agent_reasoning_effort; "
+                    "ignoring --agent-model-reasoning-level=%r for this agent.",
+                    resolved_agent_class.__name__,
+                    agent_reasoning_effort,
+                )
         agent = resolved_agent_class(
             client,
             agent_system_prompt,
             domain.tool_schemas,
             env.tool_handlers,
-            runtime_context=runtime_context,
-            retrieve_learnings_top_k=retrieve_learnings_top_k,
+            **agent_kwargs,
         )
 
     # Build simulator

--- a/state_bench/scripts/run_batch.py
+++ b/state_bench/scripts/run_batch.py
@@ -140,6 +140,7 @@ def _run_single(
     retrieve_learnings_top_k: int = 3,
     task_requirements_judge: TaskRequirementsJudge | None = None,
     ux_judge: UXQualityJudge | None = None,
+    agent_reasoning_effort: str | None = None,
 ) -> dict:
     task = TaskDefinition.load(task_file)
     user_id = task.user_id
@@ -173,6 +174,7 @@ def _run_single(
                 agent_pricing=agent_pricing,
                 agent_class=agent_class,
                 retrieve_learnings_top_k=retrieve_learnings_top_k,
+                agent_reasoning_effort=agent_reasoning_effort,
             )
 
             out_path = output_dir / f"{task.task_id}.json"
@@ -449,6 +451,7 @@ def main() -> None:
                 args.retrieve_learnings_top_k,
                 task_requirements_judge,
                 ux_judge,
+                (agent_model or {}).get("reasoning_level"),
             ): (run_idx, tf)
             for run_idx, tf in work_items
         }

--- a/state_bench/scripts/run_task.py
+++ b/state_bench/scripts/run_task.py
@@ -129,6 +129,7 @@ def _run_single_task(
     agent_model: dict[str, str | None] | None = None,
     agent_class: type[BaseAgent] | None = None,
     retrieve_learnings_top_k: int = 3,
+    agent_reasoning_effort: str | None = None,
 ) -> dict:
     user_id = user_override or task.user_id
     if not user_id:
@@ -169,6 +170,7 @@ def _run_single_task(
         agent_pricing=agent_pricing,
         agent_class=agent_class,
         retrieve_learnings_top_k=retrieve_learnings_top_k,
+        agent_reasoning_effort=agent_reasoning_effort,
     )
 
     tool_calls = []
@@ -401,6 +403,7 @@ def main() -> None:
                 agent_model,
                 agent_class,
                 args.retrieve_learnings_top_k,
+                (agent_model or {}).get("reasoning_level"),
             )
             results.append(result)
     else:
@@ -420,6 +423,7 @@ def main() -> None:
                     agent_model,
                     agent_class,
                     args.retrieve_learnings_top_k,
+                    (agent_model or {}).get("reasoning_level"),
                 ): (run_idx, task)
                 for run_idx, task in work_items
             }

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -502,3 +502,51 @@ class TestStateBenchAgentUsageTracking:
         assert agent.token_usage.reasoning_output_tokens == 40
         assert agent.token_usage.total_tokens == 1120
         assert agent.token_usage.total_cost_usd == 0.0
+
+
+class TestAgentReasoningEffort:
+    """Bug-fix regression: --agent-model-reasoning-level must reach complete_with_tools."""
+
+    def test_reasoning_effort_forwarded_to_complete_with_tools(self):
+        response = _make_response("r-1", [_make_text_item("done")], output_text="done")
+        mock = MagicMock(return_value=response)
+        pinned_client = MagicMock()
+        pinned_client.complete_with_tools = mock
+        pinned_ctx = MagicMock()
+        pinned_ctx.__enter__ = MagicMock(return_value=pinned_client)
+        pinned_ctx.__exit__ = MagicMock(return_value=False)
+        client = MagicMock(spec=PooledLLMClient)
+        client.pinned.return_value = pinned_ctx
+
+        agent = StateBenchAgent(
+            client=client,
+            system_prompt="You are a travel agent.",
+            tools=[{"type": "function", "name": "get_booking"}],
+            tool_handlers={},
+            runtime_context=_runtime_context_with_pricing(),
+            agent_reasoning_effort="high",
+        )
+        agent.act([{"role": "user", "content": "hi"}])
+
+        _, kwargs = mock.call_args
+        assert kwargs.get("reasoning_effort") == "high"
+
+    def test_reasoning_effort_default_none_forwarded(self):
+        response = _make_response("r-2", [_make_text_item("done")], output_text="done")
+        mock = MagicMock(return_value=response)
+        agent = _make_agent(mock)
+        agent.act([{"role": "user", "content": "hi"}])
+        _, kwargs = mock.call_args
+        assert kwargs.get("reasoning_effort") is None
+
+    def test_invalid_reasoning_effort_rejected(self):
+        client = MagicMock(spec=PooledLLMClient)
+        with pytest.raises(ValueError, match="agent_reasoning_effort"):
+            StateBenchAgent(
+                client=client,
+                system_prompt="x",
+                tools=[],
+                tool_handlers={},
+                runtime_context=_runtime_context_with_pricing(),
+                agent_reasoning_effort="extreme",
+            )

--- a/tests/test_client_auth.py
+++ b/tests/test_client_auth.py
@@ -149,3 +149,31 @@ def test_openai_client_rejects_third_party_base_url(monkeypatch):
 
     with pytest.raises(ValueError, match="Third-party OpenAI-compatible base URLs are not supported"):
         build_llm_client(provider="openai")
+
+
+def test_complete_with_tools_omits_temperature_when_reasoning_set(monkeypatch):
+    """Bug-fix regression: GPT-5.1 reasoning models reject `temperature` + `reasoning`."""
+    from unittest.mock import MagicMock
+
+    from state_bench.client import LLMClient
+
+    inner = MagicMock()
+    inner.responses.create.return_value = MagicMock(
+        output=[], output_text="", status="completed", incomplete_details=None
+    )
+    client = LLMClient.__new__(LLMClient)
+    client._client = inner
+    client.deployment = "gpt-5.1"
+    client.endpoint = "https://example/"
+    client.api_version = "2025-03-01-preview"
+
+    client.complete_with_tools(instructions="x", input=[], tools=[], reasoning_effort="high")
+    _, kwargs = inner.responses.create.call_args
+    assert "temperature" not in kwargs
+    assert kwargs["reasoning"] == {"effort": "high"}
+
+    inner.responses.create.reset_mock()
+    client.complete_with_tools(instructions="x", input=[], tools=[])
+    _, kwargs = inner.responses.create.call_args
+    assert kwargs.get("temperature") == 0
+    assert "reasoning" not in kwargs


### PR DESCRIPTION
Thread --agent-model-reasoning-level through the agent path so it actually controls the Responses API call instead of being trajectory metadata only. Also stop sending temperature alongside reasoning, which Azure GPT-5.1 reasoning models reject with HTTP 400.